### PR TITLE
Stubbing a value for navigator for use in Universal rendering

### DIFF
--- a/src/helpers/scrollLock.js
+++ b/src/helpers/scrollLock.js
@@ -1,5 +1,6 @@
 import getScrollbarWidth from 'scrollbar-width'
 
+let navigator = navigator || { platform: 'unknown' }
 const IS_IOS = /iPad|iPhone|iPod/.test(navigator.platform)
 
 export function lock () {


### PR DESCRIPTION
The lack of navigator object on server side rendering throws an undefined exception, added a stub for the object if it can't be found to avoid error and continue using in Universal rendered application.